### PR TITLE
Add required paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.0.0
 author=Syonyk
 maintainer=Syonyk
 sentence=MingHeBuckConverter is a software serial interface to the MingHe DPS6015 serial buck converter and related equipment.
+paragraph=
 category=Communication
 url=https://github.com/Syonyk/MingHeBuckConverter
 architectures=avr


### PR DESCRIPTION
When the `paragrap`h field is missing from library.properties, the Arduino IDE does not recognize the library:

- **Sketch > Include Library > Add .ZIP Library** fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- [Library Manager](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ) index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format